### PR TITLE
fix: handle fractional timezones in time command

### DIFF
--- a/src/structs/api/ipgeolocation.rs
+++ b/src/structs/api/ipgeolocation.rs
@@ -18,8 +18,8 @@ pub struct IPGeolocationTimeZoneLocation {
 
 #[derive(Deserialize, Debug)]
 pub struct IPGeolocationTimeZoneTz {
-    pub offset: i64,
-    pub offset_with_dst: i64,
+    pub offset: f64,
+    pub offset_with_dst: f64,
     pub date_time_txt: String,
     pub time_24: String,
     pub is_dst: bool,
@@ -43,8 +43,15 @@ impl IPGeolocationTimeZone {
         let min = time_split.next().unwrap_or_default();
         let offset = if self.time_zone.is_dst { self.time_zone.offset_with_dst } else { self.time_zone.offset };
 
+        let formatted_offset = format!(
+            "UTC{}{:02}:{:02}",
+            if offset >= 0.0 { "+" } else { "-" },
+            offset.abs().trunc() as i32,
+            (offset.abs().fract() * 60.0).round() as i32
+        );
+
         format!(
-            "It is `{}:{min} {}` or `{hour}:{min}` in {} (`{} / UTC{}`).",
+            "It is `{}:{min} {}` or `{hour}:{min}` in {} (`{} / {}`).",
             if hour == 0 || hour == 12 { 12 } else { hour % 12 },
             if hour < 12 { "AM" } else { "PM" },
             &[self.location.city.as_str(), self.location.state_prov.as_str(), self.location.country_name.as_str(),]
@@ -53,7 +60,7 @@ impl IPGeolocationTimeZone {
                 .collect::<Vec<&str>>()
                 .join(", "),
             self.time_zone.date_time_txt.split(" ").take(4).collect::<Vec<&str>>().join(" "),
-            if offset >= 0 { format!("+{offset}") } else { offset.to_string() },
+            formatted_offset,
         )
     }
 }


### PR DESCRIPTION
Aeon presently assumes timezones are in fixed hour intervals, which is sadly not the case. Running the `time` command on countries such as India and Nepal, or the capital of Australia, Adelaide, returns the following error:
```rs
Error {
    context: "Location not found.",
    source: reqwest::Error {
        kind: Decode,
        source: Error("invalid type: floating point 9.5, expected i64", line: 1, column: 233),
    },
}
```

This PR changes the type used in the struct to f64 to better match the `Number` returned by [the API](https://ipgeolocation.io/timezone-api.html#reference-to-time-zone-api-response) used, as well as the formatting, to handle such numbers.

> [!WARNING]
> I have tested the formatting as a [standalone piece of code](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=eb98e6066a4fdb2ffbacdb85017d0208), but not how it behaves inside the bot. If the formatting looks incorrect, or the deserialization still fails, please let me know.
